### PR TITLE
fix: handle non-executable GodotJS downloads

### DIFF
--- a/scripts/setup-godotjs.mjs
+++ b/scripts/setup-godotjs.mjs
@@ -288,9 +288,9 @@ function createLogger(options) {
   }
 }
 
-function findGodotBin(assetDir) {
+function findGodotBinCandidate(assetDir) {
   try {
-    return resolveGodotBin(assetDir)
+    return resolveGodotBin(assetDir, { requireExecutable: false })
   } catch {
     return null
   }
@@ -783,17 +783,18 @@ export async function setupGodotJs(options = {}) {
   }
 
   await ensureAssetArchiveExtracted(plan, log, () =>
-    Boolean(findGodotBin(plan.assetDir)),
+    Boolean(findGodotBinCandidate(plan.assetDir)),
   )
 
-  const godotBin = findGodotBin(plan.assetDir)
-  if (!godotBin) {
+  const godotBinCandidate = findGodotBinCandidate(plan.assetDir)
+  if (!godotBinCandidate) {
     throw new Error(
       `Unable to locate a Godot executable in ${path.relative(repoRoot, plan.assetDir)}`,
     )
   }
 
-  fs.chmodSync(godotBin, 0o755)
+  fs.chmodSync(godotBinCandidate, 0o755)
+  const godotBin = resolveGodotBin(godotBinCandidate)
 
   if (options.githubEnv) {
     appendGitHubEnv(options.githubEnv, {

--- a/scripts/smoke-utils.mjs
+++ b/scripts/smoke-utils.mjs
@@ -337,7 +337,7 @@ function godotCandidateRank(filePath) {
   return 3
 }
 
-function findGodotExecutableInDirectory(directory) {
+function findGodotCandidateInDirectory(directory, requireExecutable) {
   const queue = [{ directory, depth: 0 }]
 
   while (queue.length > 0) {
@@ -353,7 +353,7 @@ function findGodotExecutableInDirectory(directory) {
       if (entry.isFile() || entry.isSymbolicLink()) {
         if (
           godotExecutableNamePattern.test(entry.name) &&
-          isExecutableFile(entryPath)
+          (!requireExecutable || isExecutableFile(entryPath))
         ) {
           candidates.push(entryPath)
         }
@@ -377,11 +377,12 @@ function findGodotExecutableInDirectory(directory) {
   return null
 }
 
-export function resolveGodotBin(godotBin) {
+export function resolveGodotBin(godotBin, options = {}) {
   if (!godotBin) {
     return null
   }
 
+  const requireExecutable = options.requireExecutable ?? true
   const absoluteGodotBin = path.resolve(godotBin)
 
   if (!fs.existsSync(absoluteGodotBin)) {
@@ -390,7 +391,7 @@ export function resolveGodotBin(godotBin) {
 
   const stat = fs.statSync(absoluteGodotBin)
   if (stat.isFile()) {
-    if (!isExecutableFile(absoluteGodotBin)) {
+    if (requireExecutable && !isExecutableFile(absoluteGodotBin)) {
       throw new Error(`GODOT_BIN is not executable: ${godotBin}`)
     }
     return absoluteGodotBin
@@ -400,14 +401,19 @@ export function resolveGodotBin(godotBin) {
     throw new Error(`GODOT_BIN must be a file or directory: ${godotBin}`)
   }
 
-  const executable = findGodotExecutableInDirectory(absoluteGodotBin)
-  if (!executable) {
+  const candidate = findGodotCandidateInDirectory(
+    absoluteGodotBin,
+    requireExecutable,
+  )
+  if (!candidate) {
     throw new Error(
-      `GODOT_BIN directory does not contain an executable named like godot*: ${godotBin}`,
+      requireExecutable
+        ? `GODOT_BIN directory does not contain an executable named like godot*: ${godotBin}`
+        : `GODOT_BIN directory does not contain a file named like godot*: ${godotBin}`,
     )
   }
 
-  return executable
+  return candidate
 }
 
 export function resolveGodotCommand(options = {}) {

--- a/test/setup-godotjs.test.mjs
+++ b/test/setup-godotjs.test.mjs
@@ -15,6 +15,7 @@ import {
   installGodotJsTemplateAsset,
   pinnedGodotJsRelease,
   resolveGodotJsSetupPlan,
+  setupGodotJs,
 } from '../scripts/setup-godotjs.mjs'
 
 const repoRoot = process.cwd()
@@ -125,6 +126,40 @@ test('GodotJS setup plan rejects unknown asset kinds', () => {
     /Unsupported GodotJS asset kind: runtime/,
   )
 })
+
+test(
+  'GodotJS setup makes a downloaded 0644 editor executable before probing it',
+  { skip: process.platform === 'win32' },
+  async () => {
+    const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'vue-godot-editor-'))
+    try {
+      const release = 'fixture-release'
+      const asset = 'fixture-linux-editor'
+      const assetDir = path.join(tempRoot, release, asset)
+      const godot = path.join(assetDir, 'godot.linuxbsd.editor.dev.x86_64')
+      fs.mkdirSync(assetDir, { recursive: true })
+      fs.writeFileSync(
+        godot,
+        [
+          '#!/bin/sh',
+          'test "$1" = "--version"',
+          "printf '%s\\n' '4.4.1.fixture'",
+          '',
+        ].join('\n'),
+      )
+      fs.chmodSync(godot, 0o644)
+
+      assert.equal(fs.statSync(godot).mode & 0o777, 0o644)
+      assert.equal(
+        await setupGodotJs({ asset, cacheDir: tempRoot, release }),
+        godot,
+      )
+      assert.equal(fs.statSync(godot).mode & 0o777, 0o755)
+    } finally {
+      fs.rmSync(tempRoot, { force: true, recursive: true })
+    }
+  },
+)
 
 test('Godot export template root resolves platform user directories', () => {
   assert.equal(

--- a/test/smoke-utils.test.mjs
+++ b/test/smoke-utils.test.mjs
@@ -69,6 +69,30 @@ test('resolveGodotBin accepts a directory containing a Godot executable', () => 
   }
 })
 
+test(
+  'resolveGodotBin can discover a non-executable Godot candidate when requested',
+  { skip: process.platform === 'win32' },
+  () => {
+    const tempDir = createTempDir()
+    try {
+      const godot = path.join(tempDir, 'godot.linuxbsd.editor.dev.x86_64')
+      fs.writeFileSync(godot, 'downloaded editor')
+      fs.chmodSync(godot, 0o644)
+
+      assert.throws(
+        () => resolveGodotBin(tempDir),
+        /does not contain an executable named like godot\*/,
+      )
+      assert.equal(
+        resolveGodotBin(tempDir, { requireExecutable: false }),
+        godot,
+      )
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  },
+)
+
 test('resolveGodotBin searches nested Godot app-style directories', () => {
   const tempDir = createTempDir()
   try {


### PR DESCRIPTION
## Summary

- discover downloaded GodotJS editor files before executable validation
- apply executable permissions, then retain strict runtime validation
- add regression coverage for the upstream archive's `0644` editor mode

## Verification

- focused setup and resolver tests
- full `npm test`
- all workspace builds
- Godot Smoke: https://github.com/portwatcher/vue-godot/actions/runs/29999727323